### PR TITLE
Define custom element in componentDidMount

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ export default function customElementToReact (elementClass, options = {}) {
       })
     }
     componentDidMount () {
+      // Do not run connectedCallback before after React componentDidMount, to allow React hydration to run first
       if (!window.customElements.get(tagName)) window.customElements.define(tagName, elementClass)
       
       customProps.forEach((key) => this.props.hasOwnProperty(key) && (this.el[key] = this.props[key]))

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,8 +29,6 @@ export default function customElementToReact (elementClass, options = {}) {
   const skipProps = customProps.slice() // Keep a copy
   const tagName = `${dashCase}-${options.suffix || 'react'}`.replace(/\W+/g, '-').toLowerCase()
 
-  if (typeof window !== 'undefined' && !window.customElements.get(tagName)) window.customElements.define(tagName, elementClass)
-
   return class extends React.Component {
     constructor (props) {
       super(props)
@@ -42,6 +40,8 @@ export default function customElementToReact (elementClass, options = {}) {
       })
     }
     componentDidMount () {
+      if (typeof window !== 'undefined' && !window.customElements.get(tagName)) window.customElements.define(tagName, elementClass)
+      
       customProps.forEach((key) => this.props.hasOwnProperty(key) && (this.el[key] = this.props[key]))
       customEvents.forEach((key) => this.el.addEventListener(key, this[key]))
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ export default function customElementToReact (elementClass, options = {}) {
     componentDidMount () {
       // Do not run connectedCallback before after React componentDidMount, to allow React hydration to run first
       if (!window.customElements.get(tagName)) window.customElements.define(tagName, elementClass)
-      
+
       customProps.forEach((key) => this.props.hasOwnProperty(key) && (this.el[key] = this.props[key]))
       customEvents.forEach((key) => this.el.addEventListener(key, this[key]))
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ export default function customElementToReact (elementClass, options = {}) {
       })
     }
     componentDidMount () {
-      if (typeof window !== 'undefined' && !window.customElements.get(tagName)) window.customElements.define(tagName, elementClass)
+      if (!window.customElements.get(tagName)) window.customElements.define(tagName, elementClass)
       
       customProps.forEach((key) => this.props.hasOwnProperty(key) && (this.el[key] = this.props[key]))
       customEvents.forEach((key) => this.el.addEventListener(key, this[key]))

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -4,6 +4,18 @@ import test from 'ava'
 import path from 'path'
 import puppeteer from 'puppeteer'
 
+let originalConsole = global.console
+
+// This runs before each test
+test.beforeEach(t => {
+  originalConsole = global.console
+})
+
+// This runs after each test and other test hooks, even if they failed
+test.afterEach.always(t => {
+  global.console = originalConsole
+})
+
 async function withPage (t, run) {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
@@ -76,4 +88,43 @@ test('sets tag name from camelcased', withPage, async (t, page) => {
   await page.evaluate(() => (window.TestTest = customElementToReact(function testTest () {})))
   await page.evaluate(() => (window.comp = ReactDOM.render(<TestTest />, document.createElement('div'))))
   t.is(await page.evaluate(() => ReactDOM.findDOMNode(comp).nodeName), 'TEST-TEST-REACT')
+})
+
+test('should not run define custom element until after React has finished hydration', withPage, async (t, page) => {
+  const customElementToReact = require('./index.js').default
+  const React = require('react')
+  const ReactDOMServer = require('react-dom/server')
+  global.HTMLElement = class {}
+  const Test = customElementToReact(class Test extends HTMLElement {
+    connectedCallback () {
+      this.setAttribute('role', 'dialog')
+    }
+  })
+  const stringified = ReactDOMServer.renderToString(<Test />)
+  t.is(stringified, '<test-react data-reactroot=""></test-react>')
+
+  // Mock `console.log` so we can test if React has logged a warning
+  global.console = {
+    lastLoggedMessage: undefined,
+    log: (message) => {
+      global.console.lastLoggedMessage = message
+    }
+  }
+
+  await page.evaluate(() => (window.container = document.createElement('div')))
+  await page.evaluate((stringified) => (window.container.innerHTML = stringified), stringified)
+  await page.evaluate(() => (document.body.appendChild(window.container)))
+
+  await page.evaluate(() => (window.Test = customElementToReact(class Test extends HTMLElement {
+    connectedCallback () {
+      this.setAttribute('role', 'dialog')
+    }
+  })))
+  await page.evaluate(() => (window.test = <Test />))
+  await page.evaluate(() => (window.comp = ReactDOM.hydrate(window.test, window.container)))
+  t.is(await page.evaluate(() => ReactDOM.findDOMNode(comp).nodeName), 'TEST-REACT')
+
+  // If this test fails React will call `console.log` with the message `Warning: Extra attributes from the server: %s role`.
+  // We can't rely on this exact warning message so we simply assert that `console.log` has not been called at all.
+  t.falsy(global.console.lastLoggedMessage)
 })

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -90,7 +90,7 @@ test('sets tag name from camelcased', withPage, async (t, page) => {
   t.is(await page.evaluate(() => ReactDOM.findDOMNode(comp).nodeName), 'TEST-TEST-REACT')
 })
 
-test('should not run define custom element until after React has finished hydration', withPage, async (t, page) => {
+test('should not define custom element until after React has finished hydration', withPage, async (t, page) => {
   const customElementToReact = require('./index.js').default
   const React = require('react')
   const ReactDOMServer = require('react-dom/server')

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -62,16 +62,6 @@ test('converts from class with props and events', withPage, async (t, page) => {
   t.is(await page.evaluate(() => ReactDOM.findDOMNode(comp).getAttribute('prop3')), '')
 })
 
-test('stringifies correctly for server side rendering', (t) => {
-  const customElementToReact = require('./index.js').default
-  const React = require('react')
-  const ReactDOMServer = require('react-dom/server')
-  global.HTMLElement = class {}
-  const Test = customElementToReact(class Test extends HTMLElement {}, { props: ['prop1', 'prop2'], customEvents: ['event1', 'event2'], suffix: '1234' })
-  const stringified = ReactDOMServer.renderToString(<Test prop1 prop2 prop3 disabled onEvent1={() => {}} />)
-  t.is(stringified, '<test-1234 prop3="" disabled="" data-reactroot=""></test-1234>')
-})
-
 test('sets tag name from suffix option', withPage, async (t, page) => {
   await page.evaluate(() => (window.Test = customElementToReact(function Test () {}, { suffix: '1234' })))
   await page.evaluate(() => (window.comp = ReactDOM.render(<Test />, document.createElement('div'))))
@@ -90,7 +80,17 @@ test('sets tag name from camelcased', withPage, async (t, page) => {
   t.is(await page.evaluate(() => ReactDOM.findDOMNode(comp).nodeName), 'TEST-TEST-REACT')
 })
 
-test('should not define custom element until after React has finished hydration', withPage, async (t, page) => {
+test('stringifies correctly for server side rendering', (t) => {
+  const customElementToReact = require('./index.js').default
+  const React = require('react')
+  const ReactDOMServer = require('react-dom/server')
+  global.HTMLElement = class {}
+  const Test = customElementToReact(class Test extends HTMLElement {}, { props: ['prop1', 'prop2'], customEvents: ['event1', 'event2'], suffix: '1234' })
+  const stringified = ReactDOMServer.renderToString(<Test prop1 prop2 prop3 disabled onEvent1={() => {}} />)
+  t.is(stringified, '<test-1234 prop3="" disabled="" data-reactroot=""></test-1234>')
+})
+
+test('hydrates custom element before definition', withPage, async (t, page) => {
   const customElementToReact = require('./index.js').default
   const React = require('react')
   const ReactDOMServer = require('react-dom/server')


### PR DESCRIPTION
Defining the custom element before it has mounted means the custom element
can add attributes etc. before React has finished hydrating server rendered
markup, leading to a mismatch between the element's server rendered attributes
and what attributes the browser's DOM element React created has.