### PR TITLE
Fix memory leak

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,10 +30,7 @@ export default function customElementToReact (elementClass, options = {}) {
     map[eventName] = `on${eventName.replace(/(^|\.)./g, (m) => m.slice(-1).toUpperCase())}` // input.filter => onInputFilter
     return map
   }, {})
-  const skipProps = customProps.concat(
-    'forwardRef', // Keep a copy with forwardRef added
-    Object.keys(eventMap).map(k => eventMap[k]) // Skip props that are customEvents
-  )
+  const skipProps = customProps.concat('forwardRef', Object.keys(eventMap).map(k => eventMap[k]))
 
   const tagName = `${dashCase}-${options.suffix || 'react'}`.replace(/\W+/g, '-').toLowerCase()
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,15 @@ export default function customElementToReact (elementClass, options = {}) {
   const dashCase = name.replace(/.[A-Z]/g, ([a, b]) => `${a}-${b}`) // NameName -> name-name
   const customProps = options.props || []
   const customEvents = options.customEvents || []
-  const skipProps = customProps.concat('forwardRef') // Keep a copy with forwardRef added
+  const eventMap = customEvents.reduce((map, eventName) => {
+    map[eventName] = `on${eventName.replace(/(^|\.)./g, (m) => m.slice(-1).toUpperCase())}`
+    return map
+  }, {})
+  const skipProps = customProps.concat(
+    'forwardRef', // Keep a copy with forwardRef added
+    Object.keys(eventMap).map(k => eventMap[k]) // Skip props that are customEvents
+  )
+
   const tagName = `${dashCase}-${options.suffix || 'react'}`.replace(/\W+/g, '-').toLowerCase()
 
   return class extends React.Component {
@@ -38,10 +46,9 @@ export default function customElementToReact (elementClass, options = {}) {
         else if (this.props.forwardRef) this.props.forwardRef.current = el
         return (this.el = el)
       }
-      customEvents.forEach((eventName) => {
-        const on = `on${eventName.replace(/(^|\.)./g, (m) => m.slice(-1).toUpperCase())}` // input.filter => onInputFilter
+      Object.keys(eventMap).forEach((eventName) => {
+        const on = eventMap[eventName]
         this[eventName] = (event) => this.props[on] && closest(event.target, this.el.nodeName) === this.el && this.props[on](event)
-        skipProps.push(on) // Skip props that are customEvents
       })
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,8 @@ import React from 'react'
 
 /**
 * closest
-* @param {Element} element Element to traverse up from
-* @param {String} selector A selector to search for matching parents or element itself
+* @param {Element} el Element to traverse up from
+* @param {String} css A selector to search for matching parents or element itself
 * @return {Element|null}  Element which is the closest ancestor matching selector
 */
 const closest = (() => {
@@ -17,8 +17,8 @@ const closest = (() => {
 
 /**
 * customElementToReact
-* @param {Class|Function} elem A custom element definition.
-* @param {Array} attr Props and events
+* @param {Class|Function} elementClass A custom element definition.
+* @param {Array} options Props and custom events
 * @return {Object} A React component
 */
 export default function customElementToReact (elementClass, options = {}) {
@@ -30,48 +30,71 @@ export default function customElementToReact (elementClass, options = {}) {
     map[eventName] = `on${eventName.replace(/(^|\.)./g, (m) => m.slice(-1).toUpperCase())}` // input.filter => onInputFilter
     return map
   }, {})
-  const skipProps = customProps.concat('forwardRef', Object.keys(eventMap).map(k => eventMap[k]))
-
+  const skipProps = customProps.concat('forwardRef', Object.keys(eventMap).map(onEventName => eventMap[onEventName]))
   const tagName = `${dashCase}-${options.suffix || 'react'}`.replace(/\W+/g, '-').toLowerCase()
 
   return class extends React.Component {
     constructor (props) {
       super(props)
+      // Register ref prop for accessing custom element https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
       this.ref = (el) => {
-        // Support callback ref https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
         if (typeof this.props.forwardRef === 'function') this.props.forwardRef(el)
         else if (this.props.forwardRef) this.props.forwardRef.current = el
         return (this.el = el)
       }
+      // Register event handler on component for each custom event
       Object.keys(eventMap).forEach((eventName) => {
-        const on = eventMap[eventName]
-        this[eventName] = (event) => this.props[on] && closest(event.target, this.el.nodeName) === this.el && this.props[on](event)
+        const onEventName = eventMap[eventName]
+        this[eventName] = (event) => {
+          if (this.props[onEventName] && closest(event.target, this.el.nodeName) === this.el) {
+            this.props[onEventName](event)
+          }
+        }
       })
     }
 
     componentDidMount () {
-      // Do not run connectedCallback before after React componentDidMount, to allow React hydration to run first
-      if (!window.customElements.get(tagName)) window.customElements.define(tagName, elementClass)
+      // Run connectedCallback() after React componentDidMount() to allow React hydration to run first
+      if (!window.customElements.get(tagName)) {
+        window.customElements.define(tagName, elementClass)
+      }
 
-      customProps.forEach((key) => (key in this.props) && (this.el[key] = this.props[key]))
-      customEvents.forEach((key) => this.el.addEventListener(key, this[key]))
+      // Populate properties on custom element
+      customProps.forEach((propName) => {
+        if (propName in this.props) {
+          this.el[propName] = this.props[propName]
+        }
+      })
+
+      // Register events on custom element
+      customEvents.forEach((eventName) => {
+        this.el.addEventListener(eventName, this[eventName])
+      })
     }
 
     componentDidUpdate (prev) {
-      customProps.forEach((key) => prev[key] !== this.props[key] && (this.el[key] = this.props[key]))
+      // Sync prop changes to custom element
+      customProps.forEach((propName) => {
+        if (prev[propName] !== this.props[propName]) {
+          this.el[propName] = this.props[propName]
+        }
+      })
     }
 
     componentWillUnmount () {
-      customEvents.forEach((eventName) => this.el.removeEventListener(eventName, this[eventName]))
+      // Remove event handlers on custom element on unmount
+      customEvents.forEach((eventName) => {
+        this.el.removeEventListener(eventName, this[eventName])
+      })
     }
 
     render () {
       // Convert React props to CustomElement props https://github.com/facebook/react/issues/12810
-      return React.createElement(tagName, Object.keys(this.props).reduce((thisProps, key) => {
-        if (skipProps.indexOf(key) === -1) { // Do not render customEvents and custom props as attributes
-          if (key === 'className') thisProps.class = this.props[key] // Fixes className for custom elements
-          else if (this.props[key] === true) thisProps[key] = '' // Fixes boolean attributes
-          else if (this.props[key] !== false) thisProps[key] = this.props[key] // Pass only truthy, non-function props
+      return React.createElement(tagName, Object.keys(this.props).reduce((thisProps, propName) => {
+        if (skipProps.indexOf(propName) === -1) { // Do not render customEvents and custom props as attributes
+          if (propName === 'className') thisProps.class = this.props[propName] // Fixes className for custom elements
+          else if (this.props[propName] === true) thisProps[propName] = '' // Fixes boolean attributes
+          else if (this.props[propName] !== false) thisProps[propName] = this.props[propName] // Pass only truthy, non-function props
         }
         return thisProps
       }, { ref: this.ref }))

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ export default function customElementToReact (elementClass, options = {}) {
   const customProps = options.props || []
   const customEvents = options.customEvents || []
   const eventMap = customEvents.reduce((map, eventName) => {
-    map[eventName] = `on${eventName.replace(/(^|\.)./g, (m) => m.slice(-1).toUpperCase())}`
+    map[eventName] = `on${eventName.replace(/(^|\.)./g, (m) => m.slice(-1).toUpperCase())}` // input.filter => onInputFilter
     return map
   }, {})
   const skipProps = customProps.concat(


### PR DESCRIPTION
The `skipProps` increases in length every time the React Component is created, leading to a memory leak and performance degradation over time.

The bug, is that we push to the `skipProps` array every time the element is constructed.
https://github.com/nrkno/custom-element-to-react/blob/2d27bc9153c4c016b4ab106b8272b20220b163d0/lib/index.js#L44

I'm pretty sure this is the root cause for this graph of ever increasing response times, because `skipProps.indexOf` takes longer every time we server-side render.

![image](https://user-images.githubusercontent.com/146559/69081260-e1744e00-0a3d-11ea-86af-ea87c5aaa68b.png)
