### PR TITLE
Add optional name option and add UUID to tag name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,13 +16,22 @@ const closest = (() => {
 })()
 
 /**
+* getUUID
+* @return {String} A generated unique ID
+*/
+export function getUUID() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 5)
+}
+
+/**
 * customElementToReact
 * @param {Class|Function} elementClass A custom element definition.
 * @param {Array} options Props and custom events
 * @return {Object} A React component
 */
 export default function customElementToReact (elementClass, options = {}) {
-  const name = elementClass.name || String(elementClass).match(/function ([^(]+)/)[1] // String match for IE11
+  const suppliedName = options.name || elementClass.name || String(elementClass).match(/function ([^(]+)/)[1] // String match for IE11
+  const name = `${suppliedName}-${getUUID()}` // Add UUID to supplied name in case of duplicates
   const dashCase = name.replace(/.[A-Z]/g, ([a, b]) => `${a}-${b}`) // NameName -> name-name
   const customProps = options.props || []
   const customEvents = options.customEvents || []

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ import element from './my-element.js'
 const MyElement = customElementToReact(element, {
   props: ['prop1', 'prop2'],            // Optional. Prop names to register in React
   customEvents: ['event1', 'event2'],   // Optional. Custom events names to register in React
+  name: 'MyElementName',                // Optional. The name to be used for the inner custom element tag (CamelCase will be converted to kebab-case). Default: name property of element class definition
   suffix: '123'                         // Optional. Adds a suffix to inner custom element tag name before registering. Use to control tag name of custom element. Default: 'react'
 })
 


### PR DESCRIPTION
Closes #29 

Adds optional `name` option to the function. Also adds a generated UUID to the end of the tag name. This should alleviate any issues with duplicate elements being registered on the same tag name due to minification.

This approach might lead to the same element being registered multiple times with different tag names if it is being imported several places. This seems like a tolerable tradeoff to ensure backward compatibility. Making the `name` option mandatory would remove the need for the UUID, and avoid the issue with multiple registrations, but would be a breaking change.